### PR TITLE
fix debug usage error

### DIFF
--- a/RealtimeSTT/audio_recorder.py
+++ b/RealtimeSTT/audio_recorder.py
@@ -401,7 +401,7 @@ class AudioToTextRecorder:
             logging.debug("Explicitly setting the multiprocessing start method to 'spawn'")
             mp.set_start_method('spawn')
         except RuntimeError as e:
-            logging.debug("Start method has already been set. Details:", e)
+            logging.debug(f"Start method has already been set. Details: {e}")
 
         logging.info("Starting RealTimeSTT")
 


### PR DESCRIPTION
This PR addresses an issue occurring in debug mode when setting the threading start method using set_start_method fails. Previously, if an exception was raised during this process, the error handling code would incorrectly format the exception message, leading to a secondary exception of type TypeError with the message "not all arguments converted during string formatting."