### PR TITLE
feat: add new option "return_segments" to allow accessing word probabilities and other meta information

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,8 @@ When you initialize the `AudioToTextRecorder` class, you have various options to
 
 - **gpu_device_index** (int, default=0): GPU Device Index to use. The model can also be loaded on multiple GPUs by passing a list of IDs (e.g. [0, 1, 2, 3]).
 
+- **return_segments** (bool, default=False): Return/pass a tuple (text, segments) from any function or callback related to transcibed text (like text(), on_realtime_*, ...), which includes the raw transcribed segments instead of just the text. Useful to observe probabilities or segment timings.
+
 - **on_recording_start**: A callable function triggered when recording starts.
 
 - **on_recording_stop**: A callable function triggered when recording ends.


### PR DESCRIPTION
Currently RealtimeSTT doesn't expose the meta information about segments and their words, which are otherwise available when passing `word_timestamps=True` to the faster-whisper model. This information is very nice to have when building an application on top of RealtimeSTT, since it allow displaying word detection certainties, or to align words temporally.

This introduces a new option `return_segments` that enables `word_timestamps=True` on both the realtime and main model, and causes the related functions to take a tuple `(text, segments)` instead of just `text`. This change is opt-in and fully backward compatible.