### PR TITLE
Set exception_on_overflow=False to stream.read()

### DIFF
--- a/RealtimeSTT/audio_recorder.py
+++ b/RealtimeSTT/audio_recorder.py
@@ -835,7 +835,7 @@ class AudioToTextRecorder:
         try:
             while not shutdown_event.is_set():
                 try:
-                    data = stream.read(buffer_size)
+                    data = stream.read(buffer_size, exception_on_overflow=False)
 
                 except OSError as e:
                     if e.errno == pyaudio.paInputOverflowed:


### PR DESCRIPTION
Adding this will prevent crash loops.

`
RealTimeSTT: root - ERROR - Error during recording: [Errno -9988] Stream closed
RealTimeSTT: root - ERROR - Error during recording: [Errno -9988] Stream closed
RealTimeSTT: root - ERROR - Error during recording: [Errno -9988] Stream closed
RealTimeSTT: root - ERROR - Error during recording: [Errno -9988] Stream closed
RealTimeSTT: root - ERROR - Error during recording: [Errno -9988] Stream closed
RealTimeSTT: root - ERROR - Error during recording: [Errno -9988] Stream closed
RealTimeSTT: root - ERROR - Error during recording: [Errno -9988] Stream closed
RealTimeSTT: root - ERROR - Error during recording: [Errno -9988] Stream closed
RealTimeSTT: root - ERROR - Error during recording: [Errno -9988] Stream closed
RealTimeSTT: root - ERROR - Error during recording: [Errno -9988] Stream closed
RealTimeSTT: root - ERROR - Error during recording: [Errno -9988] Stream closed
RealTimeSTT: root - ERROR - Error during recording: [Errno -9988] Stream closed
RealTimeSTT: root - ERROR - Error during recording: [Errno -9988] Stream closed
RealTimeSTT: root - ERROR - Error during recording: [Errno -9988] Stream closed
RealTimeSTT: root - ERROR - Error during recording: [Errno -9988] Stream closed
RealTimeSTT: root - ERROR - Error during recording: [Errno -9988] Stream closed
RealTimeSTT: root - ERROR - Error during recording: [Errno -9988] Stream closed
`