### PR TITLE
prevent shutdown from hanging on Windows

### DIFF
--- a/RealtimeSTT/audio_recorder.py
+++ b/RealtimeSTT/audio_recorder.py
@@ -53,6 +53,7 @@ import copy
 import os
 import re
 import gc
+import queue
 
 # Set OpenMP runtime duplicate library handling to OK (Use only for development!)
 os.environ['KMP_DUPLICATE_LIB_OK'] = 'TRUE'
@@ -1258,7 +1259,7 @@ class AudioToTextRecorder:
 
                 try:
 
-                    data = self.audio_queue.get()
+                    data = self.audio_queue.get(True, 1)
                     if self.on_recorded_chunk:
                         self.on_recorded_chunk(data)
 
@@ -1275,8 +1276,11 @@ class AudioToTextRecorder:
                         while (self.audio_queue.qsize() >
                                 self.allowed_latency_limit):
 
-                            data = self.audio_queue.get()
+                            data = self.audio_queue.get(True, 1)
 
+                except queue.Empty:
+                  continue
+                
                 except BrokenPipeError:
                     print("BrokenPipeError _recording_worker")
                     self.is_running = False


### PR DESCRIPTION
on my system (Windows) queue.get() with no arguments will just hang during shutdown.  I'm attempting to preserve the blocking behavior of audio_queue.get() with arguments True and 1.
* True - the call still blocks, preserving your existing behavior
* 1 - blocks for at most 1 second

See https://docs.python.org/3/library/queue.html#queue.Queue.get for details.  Specifically:

"""
Prior to 3.0 on POSIX systems, and for all versions on Windows, if block is true and timeout is None, this operation goes into an uninterruptible wait on an underlying lock. This means that no exceptions can occur, and in particular a SIGINT will not trigger a KeyboardInterrupt. 
"""