### PR TITLE
Update README: Warn users about unsupported dependency versions in Linux package managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ If you didn't use CUDA models before, some additional steps might be needed one 
     
 3. **Install ffmpeg**:
 
-    > **Note**: *Installation of ffmpeg might not actually be needed to operate RealtimeSTT* <sup> *thanks to jgilbert2017 for pointing this out</sup>
+    > **Note**: *Installation of ffmpeg might not actually be needed to operate RealtimeSTT* <sup> *thanks to jgilbert2017 for pointing this out</sup>  
     > Upstream does not support the use of ffmpeg7 yet. Please ensure that the installed ffmpeg version is correct (either ffmpeg5 or ffmpeg6).
 
     You can download an installer for your OS from the [ffmpeg Website](https://ffmpeg.org/download.html).  

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ If you didn't use CUDA models before, some additional steps might be needed one 
 3. **Install ffmpeg**:
 
     > **Note**: *Installation of ffmpeg might not actually be needed to operate RealtimeSTT* <sup> *thanks to jgilbert2017 for pointing this out</sup>
+    > Upstream does not support the use of ffmpeg7 yet. Please ensure that the installed ffmpeg version is correct (either ffmpeg5 or ffmpeg6).
 
     You can download an installer for your OS from the [ffmpeg Website](https://ffmpeg.org/download.html).  
     


### PR DESCRIPTION
I noticed several issues raised by users reporting similar problems (ERROR -9998), which also occurred on my machine. The error message was vague, and it took some time to identify the root cause. This issue seems more prevalent in aggressive package managers like those in ArchLinux.

This pull request updates the README to inform users about a potential issue with Linux package managers automatically installing newer versions of dependencies that are not supported by the software. By adding this information, we aim to prevent compatibility issues and improve user experience when setting up the software on Linux systems.