### PR TITLE
Pin ctranslate2 version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ websockets==v12.0
 websocket-client==1.8.0
 openwakeword>=0.4.0
 numpy<2.0.0
+ctranslate==4.4.0


### PR DESCRIPTION
To resolve a cudnn symbol mismatch:
Unable to load any of {libcudnn_ops.so.9.1.0, libcudnn_ops.so.9.1, libcudnn_ops.so.9, libcudnn_ops.so} Invalid handle. Cannot load symbol cudnnCreateTensorDescriptor

"Here the culprit is ctranslate2. The library was just updated to version 4.5.0, which uses cuDNN 9.2. Downgrading ctranslate to version 4.4.0 is enough to fix the problem" From: https://github.com/m-bain/whisperX/issues/901