### PR TITLE
fix: clear text storage and audio frames on audio queue clear

### DIFF
--- a/RealtimeSTT/audio_recorder.py
+++ b/RealtimeSTT/audio_recorder.py
@@ -2282,6 +2282,10 @@ class AudioToTextRecorder:
         """
         self.audio_buffer.clear()
         try:
+            self.text_storage = []
+            self.realtime_stabilized_text = ""
+            self.realtime_stabilized_safetext = ""
+            self.frames = []
             while True:
                 self.audio_queue.get_nowait()
         except:


### PR DESCRIPTION
This is NOT tested very much. Look it over and make sure it's not going to induce any downstream breaking changes!