### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Although it is possible to run RealtimeSTT with a CPU installation only (use a s
 Before installing RealtimeSTT please execute:
 
 ```bash
+sudo apt-get update
+sudo apt-get install python3-dev
 sudo apt-get install portaudio19-dev
 ```
 


### PR DESCRIPTION
This solves the compilation error while building `PyAudio` because of a missing python header file.