### PR TITLE
Fixed `abort()` bug keeping the recorder running

### DIFF
--- a/RealtimeSTT/audio_recorder.py
+++ b/RealtimeSTT/audio_recorder.py
@@ -1265,6 +1265,7 @@ class AudioToTextRecorder:
         self.interrupt_stop_event.set()
         self.was_interrupted.wait()
         self.was_interrupted.clear()
+        self.stop()
 
     def wait_audio(self):
         """


### PR DESCRIPTION
Fixed a bug. 

When audio recorder is in recording state, calling `abort()` keeps the recorder running, the recorder then starts transcribing text if it gets enabled `start()` again.

The change just adds a `self.stop()` call after `abort()` code to ensure the recorder is stopped