### PR TITLE
ci: add GitHub Actions workflow for lint and import smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint (ruff)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install ruff
+        run: python -m pip install --upgrade pip ruff
+
+      - name: Run ruff (lint)
+        run: ruff check .
+
+      - name: Run ruff (format check)
+        run: ruff format --check .
+
+  import-smoke:
+    name: Import smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install package (no audio deps)
+        run: |
+          python -m pip install --upgrade pip
+          # Skip heavy audio/ML deps; just verify the package tree imports
+          python -m pip install faster-whisper halo soundfile numpy
+          python -m pip install -e . --no-deps
+
+      - name: Verify package metadata
+        run: |
+          python -c "import RealtimeSTT" && echo "RealtimeSTT import OK"
+          python -c "import setup; print('setup.py parses OK')"


### PR DESCRIPTION
## Summary

This PR adds the project's first GitHub Actions workflow under `.github/workflows/ci.yml`. The repository previously had a `.github/workflows/` directory but no workflow files, so pushes and pull requests were not validated automatically.

The new workflow runs on:
- `push` and `pull_request` against `main` / `master`
- `workflow_dispatch` (manual trigger from the Actions tab)

It contains two jobs:

1. **Lint (`ruff`)** — runs `ruff check .` and `ruff format --check .` against the entire repository on Python 3.11. This catches style regressions and common bug patterns early without requiring reviewers to run lint locally.
2. **Import smoke test** — installs the package with `pip install -e . --no-deps` plus a minimal subset of runtime dependencies (`faster-whisper`, `halo`, `soundfile`, `numpy`), then verifies that `import RealtimeSTT` succeeds and `setup.py` parses. This catches packaging / import-order breakage on every PR without pulling the heavy audio / CUDA stack.

pip caching is enabled via `actions/setup-python@v5` to keep runs fast.

## Why this option

The repo had an empty `.github/workflows/` directory and no CONTRIBUTING.md, CODE_OF_CONDUCT.md, or SECURITY.md. A CI workflow is the highest-leverage first addition: it unblocks future automated checks (typing, tests, builds) and gives contributors an immediate signal when something is broken.

## Test Plan

- [x] Workflow file is valid YAML (lint passed locally)
- [ ] CI passes on first push to the PR branch
- [ ] `Actions -> CI -> Run workflow` is available from the Actions tab (manual dispatch)
- [ ] `ruff check .` and `ruff format --check .` succeed against current `main` (some existing files may surface warnings; those can be addressed in a follow-up PR or by configuring `[tool.ruff]` `extend-ignore` / per-file overrides)