### PR TITLE
feat: Make spinner status messages configurable on AudioToTextRecorder

### DIFF
--- a/RealtimeSTT/audio_recorder.py
+++ b/RealtimeSTT/audio_recorder.py
@@ -197,6 +197,10 @@ class AudioToTextRecorder:
                  deactivity_silence_confirmation_duration: float = (
                      DEACTIVITY_SILENCE_CONFIRMATION_DURATION
                  ),
+                 spinner_listening_text: str = "speak now",
+                 spinner_wakeword_text: str = "say {wake_words}",
+                 spinner_transcribing_text: str = "transcribing",
+                 spinner_recording_text: str = "recording",
                  ):
         """
         Initializes an audio recorder and  transcription
@@ -256,6 +260,17 @@ class AudioToTextRecorder:
             feed_audio() method.
         - spinner (bool, default=True): Show spinner animation with current
             state.
+        - spinner_listening_text (str, default="speak now"): Spinner text
+            shown while listening for voice activity. Set to "" to show no
+            message.
+        - spinner_wakeword_text (str, default="say {wake_words}"): Spinner
+            text shown while waiting for wake words. ``{wake_words}`` is
+            replaced with the configured wake words. Set to "" to show no
+            message.
+        - spinner_transcribing_text (str, default="transcribing"): Spinner
+            text shown while transcribing. Set to "" to show no message.
+        - spinner_recording_text (str, default="recording"): Spinner text
+            shown while recording. Set to "" to show no message.
         - level (int, default=logging.WARNING): Logging level.
         - batch_size (int, default=16): Batch size for the main transcription
 
@@ -603,6 +618,14 @@ class AudioToTextRecorder:
             deactivity_silence_confirmation_duration=(
                 deactivity_silence_confirmation_duration
             ),
+        )
+        init_args.update(
+            {
+                "spinner_listening_text": spinner_listening_text,
+                "spinner_wakeword_text": spinner_wakeword_text,
+                "spinner_transcribing_text": spinner_transcribing_text,
+                "spinner_recording_text": spinner_recording_text,
+            }
         )
 
         initialize_recorder(

--- a/RealtimeSTT/core/initialization.py
+++ b/RealtimeSTT/core/initialization.py
@@ -210,6 +210,22 @@ def _assign_initial_attributes(recorder, init_args, normalize_wakeword_backend):
     recorder.warmup_vad = init_args["warmup_vad"]
     recorder.listen_start = 0
     recorder.spinner = init_args["spinner"]
+    recorder.spinner_listening_text = init_args.get(
+        "spinner_listening_text",
+        "speak now",
+    )
+    recorder.spinner_wakeword_text = init_args.get(
+        "spinner_wakeword_text",
+        "say {wake_words}",
+    )
+    recorder.spinner_transcribing_text = init_args.get(
+        "spinner_transcribing_text",
+        "transcribing",
+    )
+    recorder.spinner_recording_text = init_args.get(
+        "spinner_recording_text",
+        "recording",
+    )
     recorder.halo = None
     recorder.state = "inactive"
     recorder.wakeword_detected = False

--- a/RealtimeSTT/core/state.py
+++ b/RealtimeSTT/core/state.py
@@ -11,6 +11,23 @@ import halo
 logger = logging.getLogger("realtimestt")
 
 
+def _spinner_text(recorder, attribute, default):
+    """
+    Returns configured spinner text with legacy recorder-like fallback.
+    """
+    return getattr(recorder, attribute, default)
+
+
+def _wakeword_spinner_text(recorder):
+    """
+    Returns configured wake-word spinner text with wake-word interpolation.
+    """
+    text = _spinner_text(recorder, "spinner_wakeword_text", "say {wake_words}")
+    if isinstance(text, str):
+        return text.format(wake_words=getattr(recorder, "wake_words", ""))
+    return text
+
+
 def run_callback(recorder, cb, *args, **kwargs):
     """
     Runs a callback according to the recorder threading setting.
@@ -47,21 +64,34 @@ def set_recorder_state(recorder, new_state):
     if new_state == "listening":
         if recorder.on_vad_detect_start:
             run_callback(recorder, recorder.on_vad_detect_start)
-        set_spinner(recorder, "speak now")
+        set_spinner(
+            recorder,
+            _spinner_text(recorder, "spinner_listening_text", "speak now"),
+        )
         if recorder.spinner and recorder.halo:
             recorder.halo._interval = 250
     elif new_state == "wakeword":
         if recorder.on_wakeword_detection_start:
             run_callback(recorder, recorder.on_wakeword_detection_start)
-        set_spinner(recorder, f"say {recorder.wake_words}")
+        set_spinner(recorder, _wakeword_spinner_text(recorder))
         if recorder.spinner and recorder.halo:
             recorder.halo._interval = 500
     elif new_state == "transcribing":
-        set_spinner(recorder, "transcribing")
+        set_spinner(
+            recorder,
+            _spinner_text(
+                recorder,
+                "spinner_transcribing_text",
+                "transcribing",
+            ),
+        )
         if recorder.spinner and recorder.halo:
             recorder.halo._interval = 50
     elif new_state == "recording":
-        set_spinner(recorder, "recording")
+        set_spinner(
+            recorder,
+            _spinner_text(recorder, "spinner_recording_text", "recording"),
+        )
         if recorder.spinner and recorder.halo:
             recorder.halo._interval = 100
     elif new_state == "inactive":

--- a/tests/unit/test_recorder_state_callbacks.py
+++ b/tests/unit/test_recorder_state_callbacks.py
@@ -1,7 +1,17 @@
+import sys
+import types
 import unittest
 from unittest import mock
 
+try:
+    __import__("halo")
+except ModuleNotFoundError:
+    sys.modules["halo"] = types.SimpleNamespace(Halo=None)
+
 from RealtimeSTT.core import state as state_helpers
+
+
+UNSET = object()
 
 
 class FakeHalo:
@@ -19,7 +29,15 @@ class FakeHalo:
 
 
 class RecorderLike:
-    def __init__(self, state="inactive", halo=None):
+    def __init__(
+        self,
+        state="inactive",
+        halo=None,
+        spinner_listening_text=UNSET,
+        spinner_wakeword_text=UNSET,
+        spinner_transcribing_text=UNSET,
+        spinner_recording_text=UNSET,
+    ):
         self.state = state
         self.start_callback_in_new_thread = False
         self.spinner = True
@@ -30,6 +48,14 @@ class RecorderLike:
         self.on_vad_detect_stop = None
         self.on_wakeword_detection_start = None
         self.on_wakeword_detection_end = None
+        if spinner_listening_text is not UNSET:
+            self.spinner_listening_text = spinner_listening_text
+        if spinner_wakeword_text is not UNSET:
+            self.spinner_wakeword_text = spinner_wakeword_text
+        if spinner_transcribing_text is not UNSET:
+            self.spinner_transcribing_text = spinner_transcribing_text
+        if spinner_recording_text is not UNSET:
+            self.spinner_recording_text = spinner_recording_text
 
 
 class RecorderStateCallbackTests(unittest.TestCase):
@@ -129,6 +155,59 @@ class RecorderStateCallbackTests(unittest.TestCase):
         self.assertEqual(recorder.events, [])
         self.assertIs(recorder.halo, existing_halo)
         self.assertEqual(existing_halo.text, "speak now")
+
+    def test_missing_spinner_text_attributes_use_legacy_texts(self):
+        recorder = RecorderLike()
+
+        with self.patch_spinner_events():
+            with mock.patch.object(state_helpers.halo, "Halo", FakeHalo):
+                state_helpers.set_recorder_state(recorder, "listening")
+                state_helpers.set_recorder_state(recorder, "wakeword")
+                state_helpers.set_recorder_state(recorder, "recording")
+                state_helpers.set_recorder_state(recorder, "transcribing")
+
+        self.assertEqual(
+            recorder.events,
+            [
+                "spinner:speak now",
+                "spinner:say jarvis",
+                "spinner:recording",
+                "spinner:transcribing",
+            ],
+        )
+        self.assertEqual(recorder.halo.text, "transcribing")
+
+    def test_custom_listening_spinner_text_is_used(self):
+        recorder = RecorderLike(spinner_listening_text="ready when you are")
+
+        with self.patch_spinner_events():
+            with mock.patch.object(state_helpers.halo, "Halo", FakeHalo):
+                state_helpers.set_recorder_state(recorder, "listening")
+
+        self.assertEqual(recorder.events, ["spinner:ready when you are"])
+        self.assertEqual(recorder.halo.text, "ready when you are")
+
+    def test_empty_spinner_text_is_allowed(self):
+        recorder = RecorderLike(spinner_listening_text="")
+
+        with self.patch_spinner_events():
+            with mock.patch.object(state_helpers.halo, "Halo", FakeHalo):
+                state_helpers.set_recorder_state(recorder, "listening")
+
+        self.assertEqual(recorder.events, ["spinner:"])
+        self.assertEqual(recorder.halo.text, "")
+
+    def test_wakeword_spinner_text_formats_wake_words(self):
+        recorder = RecorderLike(
+            spinner_wakeword_text="waiting for {wake_words}",
+        )
+
+        with self.patch_spinner_events():
+            with mock.patch.object(state_helpers.halo, "Halo", FakeHalo):
+                state_helpers.set_recorder_state(recorder, "wakeword")
+
+        self.assertEqual(recorder.events, ["spinner:waiting for jarvis"])
+        self.assertEqual(recorder.halo.text, "waiting for jarvis")
 
     def test_run_callback_inline_preserves_call_arguments(self):
         recorder = RecorderLike()


### PR DESCRIPTION
## Summary
The user wants to remove or customize the hardcoded "Speak now" message shown by the Halo spinner. Maintainer KoljaB confirmed (2026-05-02) that this text is hardcoded and currently requires cloning the repo and editing the source line directly to change.

## Changes
Add optional constructor parameters to AudioToTextRecorder in RealtimeSTT/audio_recorder.py (e.g. spinner_listening_text="speak now", spinner_wakeword_text="say {wake_words}", spinner_transcribing_text="transcribing", spinner_recording_text="recording"), defaulting to the current literals to preserve behavior.

Fixes #300
