### PR TITLE
Fix FunASR engine returning raw SenseVoice tags

### DIFF
--- a/RealtimeSTT/transcription_engines/funasr_engine.py
+++ b/RealtimeSTT/transcription_engines/funasr_engine.py
@@ -2,6 +2,7 @@
 Adapts FunASR to the transcription engine interface.
 """
 
+import re
 from importlib import import_module
 
 from .base import (
@@ -24,7 +25,24 @@ def _load_FunASR_():
 
     return funasr
 
+_SENSEVOICE_TAG = re.compile(r"<\|[^|]*\|>")
+
+def _clean_text(text):
+    """
+        Strips SenseVoice special tags (e.g. ``<|zh|><|NEUTRAL|>``) so the
+        engine returns clean text. Uses FunASR's official postprocessor
+        when available and falls back to a tag regex otherwise. A no-op for
+        models that already emit plain text (Paraformer, Fun-ASR).
+    """
+    try:
+        from funasr.utils.postprocess_utils import rich_transcription_postprocess
+        return rich_transcription_postprocess(text)
+    except Exception:
+        return _SENSEVOICE_TAG.sub("", text)
+
 class FunASREngine(BaseTranscriptionEngine):
+
+    engine_name = "funasr"
 
     def __init__(self, config):
         """
@@ -59,7 +77,7 @@ class FunASREngine(BaseTranscriptionEngine):
 
         res = self.model.generate(input=audio)
 
-        text = res[0]["text"].strip() if res else ""
+        text = _clean_text(res[0]["text"]).strip() if res else ""
 
         return TranscriptionResult(
             text=text,


### PR DESCRIPTION
## Problem

The FunASR transcription engine returns `res[0]["text"]` verbatim:

```python
text = res[0]["text"].strip() if res else ""
```

With **SenseVoice** models (the natural pick for a low-latency real-time STT lib, since they're non-autoregressive and very fast), `res[0]["text"]` contains SenseVoice's special tags. So the engine returns e.g.

```
<|zh|><|NEUTRAL|><|Speech|><|woitn|>hello there
```

instead of `hello there`. For RealtimeSTT, which surfaces recognized text live, those tags leak straight into the displayed/streamed output.

## Fix

Clean the text with FunASR's official `rich_transcription_postprocess`, falling back to a small tag regex if it isn't importable. It's a **no-op for models that already emit plain text** (Paraformer, Fun-ASR), so every FunASR model now returns clean text. Also set `engine_name = "funasr"` (it was inheriting the base default).

Minimal diff — only `funasr_engine.py`, +19/-1.

## Verification

Ran the actual `FunASREngine.transcribe` path on GPU with `iic/SenseVoiceSmall`:

| | result |
|---|---|
| before | `<\|zh\|><\|NEUTRAL\|><\|Speech\|><\|woitn\|>欢迎大家来体验达摩院推出的语音识别模型` |
| after | `欢迎大家来体验达摩院推出的语音识别模型` |

`rich_transcription_postprocess` was also confirmed to be a no-op on already-clean text (`"今天天气不错"` → `"今天天气不错"`, `"hello world"` → `"hello world"`), so Paraformer/Fun-ASR output is unaffected.
