### PR TITLE
Fix: input_device_index validation always tests at target_sample_rate, ignoring the actual candidate rate

### DIFF
--- a/RealtimeSTT/core/audio_input_worker.py
+++ b/RealtimeSTT/core/audio_input_worker.py
@@ -82,7 +82,7 @@ def run_audio_data_worker(
                 test_stream = audio_interface.open(
                     format=pyaudio.paInt16,
                     channels=1,
-                    rate=target_sample_rate,
+                    rate=sample_rate,
                     input=True,
                     frames_per_buffer=chunk_size,
                     input_device_index=device_index,


### PR DESCRIPTION
## Root cause

Fixes #276.

`setup_audio()` in `RealtimeSTT/core/audio_input_worker.py` tries a list
of candidate sample rates in order (`sample_rates_to_try`, e.g.
`[16000, <device_native_rate>]`), calling
`initialize_audio_stream(audio_interface, sample_rate=<candidate>, ...)`
for each one.

Inside `initialize_audio_stream`, `validate_device()` is meant to confirm
the device can actually be opened/read **at the rate currently being
attempted**, but its test stream hardcodes `rate=target_sample_rate` (the
module-level 16000 Hz VAD-native constant) instead of using the
`sample_rate` parameter that names the current candidate:

```python
test_stream = audio_interface.open(
    format=pyaudio.paInt16,
    channels=1,
    rate=target_sample_rate,   # <- always 16000, ignores the candidate
    ...
)
```

Consequence: for any device whose PortAudio backend rejects 16000 Hz
(e.g. many USB microphones on both macOS CoreAudio and Linux ALSA that
only advertise 48000 Hz — see the device info logs on #276: `GeniusMic
UC: USB Audio` / `USB Audio Device`, both `defaultSampleRate: 48000`),
`validate_device()` fails with `Invalid sample rate` on the very first
(16000 Hz) attempt, and `setup_audio()` never even reaches the real
`audio_interface.open(rate=sample_rate, ...)` call a few lines below
that would have correctly opened the stream at 48000 Hz. The outer loop
then reports `Selected device validation failed` /
`Failed to initialize audio stream with all sample rates`, and the
recorder silently falls back to the default device — matching the
reporter's logs exactly.

## Verification

Reproduced on a clean venv (Python 3.13, macOS, `RealtimeSTT==1.0.2` —
current PyPI release) using a mock PortAudio device that only accepts
48000 Hz (mirroring the reporter's device info):

```
candidate_rate=16000: BUGGY(hardcoded target_sample_rate)=(False, 'Invalid sample rate')  FIXED(uses actual candidate rate)=(False, 'Invalid sample rate')
candidate_rate=48000: BUGGY(hardcoded target_sample_rate)=(False, 'Invalid sample rate')  FIXED(uses actual candidate rate)=True
```

With the current code, validation fails at every candidate rate because
it always probes at 16000 Hz regardless of which rate is actually being
attempted. With `rate=sample_rate`, validation succeeds once the
candidate matches the device's real supported rate, with no other
change to behavior.

## Fix

One-line change: use the `sample_rate` parameter (the rate
`setup_audio()` is currently trying) instead of the module-level
`target_sample_rate` constant in `validate_device()`'s test-stream call,
matching the real stream-open call a few lines below it in the same
function.

---
This change was drafted with AI assistance (repro script + patch), then manually verified against the current PyPI release before submission.
