### PR TITLE
Fix typo: thread.deamon -> thread.daemon in core/runtime.py

### DIFF
--- a/RealtimeSTT/core/runtime.py
+++ b/RealtimeSTT/core/runtime.py
@@ -24,7 +24,7 @@ def start_recorder_worker(target=None, args=()):
     """
     if (platform.system() == 'Linux'):
         thread = threading.Thread(target=target, args=args)
-        thread.deamon = True
+        thread.daemon = True
         thread.start()
         return thread
     else:


### PR DESCRIPTION
## Summary
- Fixes a one-line typo in `RealtimeSTT/core/runtime.py` line 27: `thread.deamon = True` should be `thread.daemon = True`.
- Because Python `Thread` objects allow arbitrary attribute assignment, the typo silently created a bogus `deamon` attribute instead of setting the real `daemon` flag, leaving the worker thread non-daemon. This can prevent the host process from exiting cleanly.

## Verification
- Searched the whole repo for `deamon` — only the one occurrence found and fixed; zero remaining after the change.
- Confirmed no other code references `.deamon` (i.e. nothing relies on the buggy behavior).
- Verified the file parses correctly after the change.

Fixes #325

_Note: this fix was prepared with AI assistance (no CONTRIBUTING.md disclosure requirement found in the repo)._